### PR TITLE
Updating podspec to include vendored framework for subspec

### DIFF
--- a/PWLocation.podspec
+++ b/PWLocation.podspec
@@ -22,6 +22,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'NoAds' do |sub|
+    sub.ios.vendored_frameworks = 'Framework/PWLocation.framework'
     sub.dependency 'PWCoreNoAds', '~> 3.8.0'
   end
                                                 


### PR DESCRIPTION
subspecs did not include the framework, so we've updated the NoAds subspec to include the framework so that it will install correctly when this subspec is used in another project's Podfile